### PR TITLE
Add functions for compatibility with Quoya Smart Curtains

### DIFF
--- a/Tuya/TuyaOpenCloudAPI.groovy
+++ b/Tuya/TuyaOpenCloudAPI.groovy
@@ -142,7 +142,7 @@ metadata {
     'colour'         : [ 'colour_data', 'colour_data_v2' ],
     'contact'        : [ 'doorcontact_state' ],
     'ct'             : [ 'temp_value', 'temp_value_v2' ],
-    'control'        : [ 'control' ],
+    'control'        : [ 'control', 'mach_operate' ],
     'fanSpeed'       : [ 'fan_speed' ],
     'light'          : [ 'switch_led', 'switch_led_1', 'light' ],
     'humiditySet'    : [ 'dehumidify_set_value' ],                                                                                       /* Inserted by SJB */
@@ -152,7 +152,7 @@ metadata {
     'omniSensor'     : [ 'bright_value', 'humidity_value', 'va_humidity', 'bright_sensitivity', 'shock_state', 'inactive_state', 'sensitivity' ],
     'pir'            : [ 'pir' ],
     'power'          : [ 'Power', 'power', 'switch', 'switch_1', 'switch_2', 'switch_3', 'switch_4', 'switch_5', 'switch_6', 'switch_usb1', 'switch_usb2', 'switch_usb3', 'switch_usb4', 'switch_usb5', 'switch_usb6', 'alarm_switch' ],
-    'percentControl' : [ 'percent_control', 'fan_speed_percent' ],
+    'percentControl' : [ 'percent_control', 'fan_speed_percent', 'position' ],
     'push'           : [ 'manual_feed' ],
     'sceneSwitch'    : [ 'switch1_value', 'switch2_value', 'switch3_value', 'switch4_value', 'switch_mode2', 'switch_mode3', 'switch_mode4' ],
     'smoke'          : [ 'smoke_sensor_status' ],
@@ -241,7 +241,10 @@ void componentClose(DeviceWrapper dw) {
     Map<String, Map> functions = getFunctions(dw)
     String code = getFunctionCode(functions, tuyaFunctions.control)
 
-    if (code != null) {
+    if (code == 'mach_operate') {
+        if (txtEnable) { LOG.info "Closing ${dw}" }
+        tuyaSendDeviceCommandsAsync(dw.getDataValue('id'), [ 'code': code, 'value': 'ZZ' ])
+    } else if (code != null) {
         if (txtEnable) { LOG.info "Closing ${dw}" }
         tuyaSendDeviceCommandsAsync(dw.getDataValue('id'), [ 'code': code, 'value': 'close' ])
     } else {
@@ -309,7 +312,10 @@ void componentOpen(DeviceWrapper dw) {
     Map<String, Map> functions = getFunctions(dw)
     String code = getFunctionCode(functions, tuyaFunctions.control)
 
-    if (code != null) {
+    if (code == 'mach_operate') {
+        if (txtEnable) { LOG.info "Opening ${dw}" }
+        tuyaSendDeviceCommandsAsync(dw.getDataValue('id'), [ 'code': code, 'value': 'FZ' ])
+    } else if (code != null) {
         if (txtEnable) { LOG.info "Opening ${dw}" }
         tuyaSendDeviceCommandsAsync(dw.getDataValue('id'), [ 'code': code, 'value': 'open' ])
     } else {
@@ -573,7 +579,10 @@ void componentStopPositionChange(DeviceWrapper dw) {
     Map<String, Map> functions = getFunctions(dw)
     String code = getFunctionCode(functions, tuyaFunctions.control)
 
-    if (code != null) {
+    if (code == 'mach_operate') {
+        if (txtEnable) { LOG.info "Stopping ${dw}" }
+        tuyaSendDeviceCommandsAsync(dw.getDataValue('id'), [ 'code': code, 'value': 'STOP' ])
+    } else if (code != null) {
         if (txtEnable) { LOG.info "Stopping ${dw}" }
         tuyaSendDeviceCommandsAsync(dw.getDataValue('id'), [ 'code': code, 'value': 'stop' ])
     } else {
@@ -1287,6 +1296,8 @@ private List<Map> createEvents(DeviceWrapper dw, List<Map> statusList) {
                 case 'opening': value = 'opening'; break
                 case 'close': value = 'closed'; break
                 case 'closing': value = 'closing'; break
+                case 'ZZ': value = 'closed'; break
+                case 'FZ': value = 'open'; break
                 case 'stop': value = 'unknown'; break
             }
             if (value) {
@@ -1447,7 +1458,7 @@ private List<Map> createEvents(DeviceWrapper dw, List<Map> statusList) {
             return [ [ name: 'motion', value: value, descriptionText: "motion is ${value}" ] ]
         }
 
-        if (status.code in tuyaFunctions.percent_control) {
+        if (status.code in tuyaFunctions.percentControl) {
             if (txtEnable) { LOG.info "${dw} position is ${status.value}%" }
             return [ [ name: 'position', value: status.value, descriptionText: "position is ${status.value}%", unit: '%' ] ]
         }


### PR DESCRIPTION
Added functions so the drive will work with Quoya smart curtains using the shade driver.
1) added position command to the percentControl function as this is what Quoya uses.
2) Added mach_operate command to the control function (close/open) and to the status function to show whether the curtains are opened or closed.  FZ, ZZ and STOP (uppercase)
3) Fixed a typo in the tuyaFunctiions.percentControl so percent reporting would be saved.

If there is another preferred way to do #1 and #2 please feel free.  Here are how the functions of these curtains are reported:
functions: {"mach_operate":{"range":["ZZ","FZ","STOP"],"type":"Enum"},"opposite":{"type":"Boolean"},"position":{"unit":"%","min":0,"max":100,"scale":0,"step":1,"type":"Integer"}}

Here is where the curtains can be purchased:
https://smile.amazon.com/gp/product/B07X3XTFWS/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&th=1