### PR TITLE
Add DP Instruction support (DeHumidifer)

### DIFF
--- a/Component/ComponentDehumidifier.groovy
+++ b/Component/ComponentDehumidifier.groovy
@@ -15,6 +15,11 @@ metadata {
         attribute 'switch', 'string'
         attribute 'mode', 'string'
         attribute 'anion', 'string'
+        attribute 'waterPump', 'string'
+        attribute 'insideDrying', 'string'
+        attribute 'countdown', 'number'
+        attribute 'countdown_left', 'number'
+        attribute 'fault', 'string'
     }
 
     command 'setHumidity', [[name:'humidityNeeded', type: 'ENUM', constraints: ['35', '40', '45', '50', '55', '60', '65', '70', '75', '80'], description: 'Set Humidity']]

--- a/Tuya/TuyaOpenCloudAPI.groovy
+++ b/Tuya/TuyaOpenCloudAPI.groovy
@@ -155,7 +155,7 @@ metadata {
     'light'          : [ 'switch_led', 'switch_led_1', 'light' ],
     'humiditySet'    : [ 'dehumidify_set_value' ],                                                                                       /* Inserted by SJB */
     'humiditySpeed'  : [ 'fan_speed_enum' ],
-    'humidity'       : [ 'temp_indoor', 'swing', 'child_lock', 'fan_speed_enum', 'dehumidify_set_value', 'humidity_indoor', 'switch', 'mode', 'anion' ],
+    'humidity'       : [ 'temp_indoor', 'swing', 'shake', 'child_lock', 'lock', 'fan_speed_enum', 'dehumidify_set_value', 'humidity_indoor', 'humidity', 'envhumid', 'switch', 'mode', 'anion', 'pump', 'dry', 'windspeed', 'countdown', 'countdown_left', 'fault' ],
     'meteringSwitch' : [ 'countdown_1' , 'add_ele' , 'cur_current', 'cur_power', 'cur_voltage' , 'relay_status', 'light_mode' ],
     'omniSensor'     : [ 'bright_value', 'humidity_value', 'va_humidity', 'bright_sensitivity', 'shock_state', 'inactive_state', 'sensitivity' ],
     'pir'            : [ 'pir' ],
@@ -1595,26 +1595,32 @@ private List<Map> createEvents(DeviceWrapper dw, List<Map> statusList) {
                     value = scale(status.value, (int)set.scale)
                     unit = set.unit
                     break
+                case 'shake':
                 case 'swing':
                     name = 'swing'
-                    value = status.value
+                    value = status.value ? 'on' : 'off'
                     unit = ''
                     break
+                case 'lock':
                 case 'child_lock':
                     name = 'child_lock'
-                    value = status.value
+                    value = status.value ? 'on' : 'off'
                     unit = ''
                     break
+                case 'windspeed':
+                case 'speed':
                 case 'fan_speed_enum':
                     name = 'speed'
-                    value = status.value
+                    value = (status.value?.toInteger() == 0 ? 'high' : 'low')
                     unit = ''
                     break
+                case 'humidity':
                 case 'dehumidify_set_value':
                     name = 'humiditySetpoint'
                     value = scale(status.value, (int)set.scale)
                     unit = 'RH%'
                     break
+                case 'envhumid':
                 case 'humidity_indoor':
                     name = 'humidity'
                     value = scale(status.value, (int)set.scale)
@@ -1622,12 +1628,61 @@ private List<Map> createEvents(DeviceWrapper dw, List<Map> statusList) {
                     break
                 case 'mode':
                     name = 'mode'
-                    value = status.value
+                    value = (status.value?.toInteger() == 0 ? 'auto' : 'continuous')
                     unit = ''
                     break
                 case 'anion':
                     name = 'anion'
+                    value = status.value ? 'on' : 'off'
+                    unit = ''
+                    break
+                case 'pump':
+                    name = 'waterPump'
+                    value = status.value ? 'on' : 'off'
+                    unit = ''
+                    break
+                case 'dry':
+                    name = 'insideDrying'
+                    value = status.value ? 'on' : 'off'
+                    unit = ''
+                    break
+                case 'countdown':
+                    name = 'countdown'
                     value = status.value
+                    unit = 'Hours'
+                    break
+                case 'countdown_left':
+                    name = 'countdown_left'
+                    value = status.value
+                    unit = 'Minutes'
+                    break
+                case 'fault':
+                    name = 'fault'
+                    switch (status.value) {
+                      case 0:
+                        value = 'ok'
+                      break
+                      case 1:
+                        value = 'temperature sensor failure (E2)'
+                      break
+                      case 2:
+                        value = 'coil sensor (E1)'
+                      break
+                      case 4:
+                        value = 'defrost (P1)'
+                      break
+                      case 8:
+                        value = 'water full (FL)'
+                      break
+                      case 16:
+                        value = 'low temperature alarm (LO)'
+                      break
+                      case 32:
+                        value = 'high temperature alarm (HI)'
+                      break
+                      default:
+                        value = 'unknown ('+ status.value +')'
+                    }
                     unit = ''
                     break
                 default:


### PR DESCRIPTION
This add suppoort for the extra device status fields.

This now needs to be enabled on each device by switching from “Standard Instruction” to "DP Instruction”:
![CleanShot 2022-12-08 at 7 15 54](https://user-images.githubusercontent.com/333081/206533794-02e14cff-5dc0-46b7-8911-a0ad40c7f37d.png)
![CleanShot 2022-12-08 at 7 16 53](https://user-images.githubusercontent.com/333081/206534053-497e887f-81dd-4364-87bc-afa6230a91ac.png)


With this we can now trigger alerts when the water tank is full :-)