### PR TITLE
Fix issue where state is cleared but never repopulated for FanControl

### DIFF
--- a/ESPHome/ESPHome-FanControl.groovy
+++ b/ESPHome/ESPHome-FanControl.groovy
@@ -135,6 +135,7 @@ public void refresh() {
     log.info "${device} refresh"
     state.clear()
     espHomeDeviceInfoRequest()
+    espHomeListEntitiesRequest()
 }
 
 public void setSpeed(String speed) {


### PR DESCRIPTION
Fixes issue where if at any point the refresh method is executed, it clears the "fans" state variable, which then causes the entity list to not populate correctly and also then prohibits any state updates from occurring correctly.
 