### PR TITLE
Bump HPM package to 1.3.2 so users are offered the library update

### DIFF
--- a/ESPHome/packageManifest.json
+++ b/ESPHome/packageManifest.json
@@ -1,13 +1,13 @@
 {
   "packageName": "ESPHome Native API Library",
   "author": "Jonathan Bradshaw",
-  "version": "1.2",
+  "version": "1.3.2",
   "minimumHEVersion": "2.1.9",
   "communityLink": "https://community.hubitat.com/t/esphome-hubitat/68341",
   "documentationLink": "https://github.com/bradsjm/hubitat-drivers/blob/main/ESPHome/README.md",
   "licenseFile": "https://raw.githubusercontent.com/bradsjm/hubitat-drivers/main/LICENSE",
-  "dateReleased": "2024-03-03",
-  "releaseNotes": "v1.2 - Add support for calling ESPHome user-defined services.",
+  "dateReleased": "2026-08-01",
+  "releaseNotes": "v1.3.2 - Required for ESPHome 2026.7 and newer, which no longer sends object_id over the native API: the library now declares API version 1.14 and derives object_id from the entity name, so drivers find their entities again. Also includes everything from v1.3, which HPM was never offered: climate entity support, sub-device (device_id) decoding, and handshake fixes for ESPHome 2025.10+ where the device auto-authenticates and sends no ConnectResponse.",
   "bundles": [
     {
       "id": "948fa4dc-8209-442b-b590-749f0ae899a0",


### PR DESCRIPTION
Follow-up to #46. That fixed the library, but no HPM user will actually receive it until this lands.

## Why

HPM decides whether to offer an existing install an update by comparing the `version` field in `packageManifest.json`. It has read **`1.2` since 2024-03-03**, so no HPM user has ever been offered v1.3, v1.3.1 or v1.3.2 — they are all still running the v1.2 library.

That is now user-visible breakage rather than just staleness. ESPHome 2026.7.0 ([esphome#17108](https://github.com/esphome/esphome/pull/17108)) stopped sending `object_id` over the native API, so a v1.2 library matches **no entities at all** against current firmware. Six of the example drivers in this repo identify entities by `objectId` and are affected:

`ESPHome-AthomHumanPresenceSensor`, `ESPHome-EverythingPresenceOne`, `ESPHome-MultiSwitch`, `ESPHome-MultiSwitchSensor`, `ESPHome-MultiContactSensor`, `ESPHome-UpsyDesky`

## No location change is needed

I checked this before assuming otherwise — the bundle URL is already correct:

- It points at `.../main/ESPHome-API-Library-Bundle.zip`, so it tracks whatever is on `main`.
- I downloaded it and confirmed it already contains `API_HELPER_VERSION = '1.3.2'` with the fix.
- The `bradsjm/hubitat-drivers` hostname in the manifest is a **permanent GitHub redirect** after the repo rename (`GET /repos/bradsjm/hubitat-drivers` → `301 Moved Permanently`), and the zip it serves is byte-identical to the `hubitat-public` copy — same SHA-256.

So the `version` field was the only thing holding the update back.

## What changed

Three fields, matching the convention in 096818e:

| Field | Before | After |
| --- | --- | --- |
| `version` | `1.2` | `1.3.2` |
| `dateReleased` | `2024-03-03` | `2026-08-01` |
| `releaseNotes` | v1.2 note | covers 1.3 → 1.3.2 |

The release notes deliberately mention the v1.3 features too, since HPM users are jumping two releases and were never offered the intermediate ones.

Driver entries are left at `1.0` — no driver file changed, the fix is entirely in the shared library bundle.

## Note for a future cleanup (not in this PR)

Every URL in this manifest still uses the old `bradsjm/hubitat-drivers` repo name, as do the `importUrl` fields in the driver files. They work today purely because of GitHub's rename redirect. Worth repointing to `hubitat-public` at some stage so it does not depend on that redirect surviving — happy to send a separate PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)